### PR TITLE
fix intermittent failure on aws path spec

### DIFF
--- a/config/initializers/aws.rb
+++ b/config/initializers/aws.rb
@@ -19,7 +19,7 @@ module Panoptes
   end
 
   def self.export_bucket_path
-    @bucket_path ||= aws_config[:export_bucket_path]
+    @export_bucket_path ||= aws_config[:export_bucket_path]
   end
 end
 


### PR DESCRIPTION
My bad, silly mistake caching in the wrong instance variable. 
