### PR TITLE
spec the media storage paths

### DIFF
--- a/app/models/medium.rb
+++ b/app/models/medium.rb
@@ -7,11 +7,12 @@ class Medium < ActiveRecord::Base
     nil
   end
 
-  ALLOWED_CONTENT_TYPES = %w(image/jpeg image/png image/gif)
+  ALLOWED_UPLOAD_CONTENT_TYPES = %w(image/jpeg image/png image/gif)
+  ALLOWED_EXPORT_CONTENT_TYPES  = %w(text/csv)
 
   validate do |medium|
-    unless ALLOWED_CONTENT_TYPES.include?(medium.content_type)
-      medium.errors.add(:content_type, "Content-Type must be one of #{ALLOWED_CONTENT_TYPES.join(", ")}")
+    unless allowed_content_types.include?(medium.content_type)
+      medium.errors.add(:content_type, "Content-Type must be one of #{allowed_content_types.join(", ")}")
     end
   end
 
@@ -41,5 +42,13 @@ class Medium < ActiveRecord::Base
 
   def put_file(file_path)
     MediaStorage.put_file(src, file_path, indifferent_attributes)
+  end
+
+  def allowed_content_types
+    if type == "classifications_export"
+      ALLOWED_EXPORT_CONTENT_TYPES
+    else
+      ALLOWED_UPLOAD_CONTENT_TYPES
+    end
   end
 end

--- a/app/models/medium.rb
+++ b/app/models/medium.rb
@@ -1,7 +1,8 @@
 class Medium < ActiveRecord::Base
   belongs_to :linked, polymorphic: true
 
-  before_save :create_path, unless: :external_link
+  before_validation :create_path, unless: :external_link
+  validates :src, presence: true, unless: :external_link
 
   def self.inheritance_column
     nil

--- a/app/models/medium.rb
+++ b/app/models/medium.rb
@@ -1,4 +1,7 @@
 class Medium < ActiveRecord::Base
+
+  class MissingPutFilePath < StandardError; end
+
   belongs_to :linked, polymorphic: true
 
   before_validation :create_path, unless: :external_link
@@ -42,6 +45,9 @@ class Medium < ActiveRecord::Base
   end
 
   def put_file(file_path)
+    if file_path.blank?
+      raise MissingPutFilePath.new("Must specify a file_path to store")
+    end
     MediaStorage.put_file(src, file_path, indifferent_attributes)
   end
 

--- a/app/workers/classifications_dump_worker.rb
+++ b/app/workers/classifications_dump_worker.rb
@@ -41,11 +41,11 @@ class ClassificationsDumpWorker
   end
 
   def medium
-    @medium ||= Medium.create(content_type: "text/csv",
-                              type: "classifications_export",
-                              path_opts: project_file_path,
-                              linked: project,
-                              private: true)
+    @medium ||= Medium.create!(content_type: "text/csv",
+                               type: "classifications_export",
+                               path_opts: project_file_path,
+                               linked: project,
+                               private: true)
   end
 
   def write_to_s3

--- a/lib/media_storage/abstract_adapter.rb
+++ b/lib/media_storage/abstract_adapter.rb
@@ -1,5 +1,8 @@
 module MediaStorage
   class AbstractAdapter
+
+    class EmptyPathError < StandardError; end
+
     def initialize(opts={})
       @opts = opts
     end
@@ -22,6 +25,14 @@ module MediaStorage
 
     def configure
       yield self if block_given?
+    end
+
+    private
+
+    def check_path(path)
+      if path.blank?
+        raise EmptyPathError.new("A storage path must be specified.")
+      end
     end
   end
 end

--- a/lib/media_storage/aws_adapter.rb
+++ b/lib/media_storage/aws_adapter.rb
@@ -1,5 +1,6 @@
 module MediaStorage
   class AwsAdapter < AbstractAdapter
+
     DEFAULT_PUT_EXPIRATION = 20
     DEFAULT_GET_EXPIRATION = 60
 
@@ -62,6 +63,7 @@ module MediaStorage
     private
 
     def object(path)
+      check_path(path)
       bucket.objects[path]
     end
 

--- a/spec/lib/media_storage/aws_adapter_spec.rb
+++ b/spec/lib/media_storage/aws_adapter_spec.rb
@@ -73,7 +73,6 @@ RSpec.describe MediaStorage::AwsAdapter do
       allow(adapter).to receive(:object).and_return(obj_double)
     end
 
-
     context "when opts[:private] is true" do
       it 'should call write with the content_type, file, and private acl' do
         expect(obj_double).to receive(:write).with(file: file_path,
@@ -90,6 +89,16 @@ RSpec.describe MediaStorage::AwsAdapter do
                                                    acl: 'public-read')
         adapter.put_file("src", file_path, content_type: content_type, private: false)
       end
+    end
+  end
+
+  context "when missing an s3 object path" do
+
+    it 'should raise an error' do
+      error_message = "A storage path must be specified."
+      expect do
+        adapter.send(:object, nil)
+      end.to raise_error(MediaStorage::AbstractAdapter::EmptyPathError, error_message)
     end
   end
 end

--- a/spec/models/medium_spec.rb
+++ b/spec/models/medium_spec.rb
@@ -105,4 +105,31 @@ RSpec.describe Medium, :type => :model do
       end
     end
   end
+
+  describe "#put_file" do
+
+    let(:file_path) { "#{Rails.root}/tmp/project_x_dump.csv" }
+    let(:media_storage_put_file_params) { [ medium.src, file_path, medium.attributes ]}
+
+    it 'should call MediaStorage with the src and other attributes' do
+      expect(MediaStorage).to receive(:put_file).with(*media_storage_put_file_params)
+      medium.put_file(file_path)
+    end
+
+    it 'should pass attributes as hash with indifferent access' do
+      expect(MediaStorage).to receive(:put_file)
+        .with(anything, anything, be_a(HashWithIndifferentAccess))
+      medium.put_file(file_path)
+    end
+
+    context "when passed a blank file_path" do
+      let!(:file_path) { "" }
+
+      it 'should raise and error' do
+        expect {
+          medium.put_file(file_path)
+        }.to raise_error(Medium::MissingPutFilePath, "Must specify a file_path to store")
+      end
+    end
+  end
 end

--- a/spec/models/medium_spec.rb
+++ b/spec/models/medium_spec.rb
@@ -23,8 +23,24 @@ RSpec.describe Medium, :type => :model do
     expect(m).to be_valid
   end
 
+  context "when the src field is blank" do
+    before(:each) do
+      allow(MediaStorage).to receive(:stored_path).and_return(nil)
+    end
+
+    it 'should not be valid without a src' do
+      expect(medium).to be_invalid
+    end
+
+    it 'should have a useful error message' do
+      medium.valid?
+      expect(medium.errors[:src]).to include("can't be blank")
+    end
+  end
+
   describe "#create_path" do
     context "when not externally linked" do
+
       it 'should create src path when saved' do
         medium.save!
         expect(medium.src).to be_a(String)

--- a/spec/workers/classifications_dump_worker_spec.rb
+++ b/spec/workers/classifications_dump_worker_spec.rb
@@ -42,6 +42,15 @@ RSpec.describe ClassificationsDumpWorker do
         worker.perform(project.id)
       end
 
+      it "should create a linked media resource" do
+        expect(Medium).to receive(:create!).and_call_original
+        worker.perform(project.id)
+      end
+
+      it "should not fail to create a linked media resource" do
+        expect { worker.perform(project.id) }.to_not raise_error
+      end
+
       it "push the file to s3" do
         expect(worker).to receive(:write_to_s3).once
         worker.perform(project.id)


### PR DESCRIPTION
Adding some specs around nil paths making it into the s3 put_file where the medium resource wasn't valid via the `Medium.create` method (and thus the src) was nil before attempting to write to s3.